### PR TITLE
Adds PHP 8.0 support, removes support for all versions prior to 7.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.phpunit.result.cache
 /clover.xml
 /composer.lock
 /coveralls-upload.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,40 +12,31 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.6
+    - php: 7.3
       env:
         - DEPS=lowest
-    - php: 5.6
-      env:
-        - DEPS=latest
-        - TEST_COVERAGE=true
-    - php: 7
-      env:
-        - DEPS=lowest
-    - php: 7
+    - php: 7.3
       env:
         - DEPS=latest
         - CS_CHECK=true
-    - php: 7.1
-      env:
-        - DEPS=lowest
-    - php: 7.1
-      env:
-        - DEPS=latest
         - TEST_COVERAGE=true
         - BENCHMARKS=true
-    - php: 7.2
+    - php: 7.4
       env:
         - DEPS=lowest
-    - php: 7.2
+    - php: 7.4
       env:
         - DEPS=latest
-    - php: 7.3
+    - php: nightly
       env:
         - DEPS=lowest
-    - php: 7.3
+        - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
+    - php: nightly
       env:
         - DEPS=latest
+        - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
+  allow_failures:
+    - php: nightly
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || true ; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
+- [#10](https://github.com/laminas/laminas-eventmanager/pull/10) adds support for the upcoming PHP 8.0 release.
+
 - [zendframework/zend-eventmanager#72](https://github.com/zendframework/zend-eventmanager/pull/72) adds support for PHP 7.3.
 
 ### Changed
@@ -18,7 +20,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Removed
 
-- Nothing.
+- [#10](https://github.com/laminas/laminas-eventmanager/pull/10) removes support for PHP versions prior to PHP 7.3.
 
 ### Fixed
 

--- a/composer.json
+++ b/composer.json
@@ -27,18 +27,18 @@
         }
     },
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.3 || ^8.0",
         "laminas/laminas-zendframework-bridge": "^1.0"
     },
     "require-dev": {
-        "container-interop/container-interop": "^1.1.0",
+        "container-interop/container-interop": "^1.1",
         "laminas/laminas-coding-standard": "~1.0.0",
         "laminas/laminas-stdlib": "^2.7.3 || ^3.0",
-        "phpbench/phpbench": "^0.13",
-        "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2"
+        "phpbench/phpbench": "^0.17.1",
+        "phpunit/phpunit": "^8.5.8"
     },
     "suggest": {
-        "container-interop/container-interop": "^1.1.0, to use the lazy listeners feature",
+        "container-interop/container-interop": "^1.1, to use the lazy listeners feature",
         "laminas/laminas-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature"
     },
     "autoload": {

--- a/test/EventManagerAwareTraitTest.php
+++ b/test/EventManagerAwareTraitTest.php
@@ -20,26 +20,26 @@ class EventManagerAwareTraitTest extends TestCase
     {
         $object = $this->getObjectForTrait(EventManagerAwareTrait::class);
 
-        $this->assertAttributeEquals(null, 'events', $object);
+        self::assertAttributeEquals(null, 'events', $object);
 
         $eventManager = new EventManager;
 
         $object->setEventManager($eventManager);
 
-        $this->assertAttributeEquals($eventManager, 'events', $object);
+        self::assertAttributeEquals($eventManager, 'events', $object);
     }
 
     public function testGetEventManager()
     {
         $object = $this->getObjectForTrait(EventManagerAwareTrait::class);
 
-        $this->assertInstanceOf(EventManagerInterface::class, $object->getEventManager());
+        self::assertInstanceOf(EventManagerInterface::class, $object->getEventManager());
 
         $eventManager = new EventManager;
 
         $object->setEventManager($eventManager);
 
-        $this->assertSame($eventManager, $object->getEventManager());
+        self::assertSame($eventManager, $object->getEventManager());
     }
 
     public function testSetEventManagerWithEventIdentifier()
@@ -53,9 +53,9 @@ class EventManagerAwareTraitTest extends TestCase
         $object->setEventManager($eventManager);
 
         //check that the identifier has been added.
-        $this->assertContains($eventIdentifier, $eventManager->getIdentifiers());
+        self::assertContains($eventIdentifier, $eventManager->getIdentifiers());
 
         //check that the method attachDefaultListeners has been called
-        $this->assertTrue($object->defaultEventListenersCalled());
+        self::assertTrue($object->defaultEventListenersCalled());
     }
 }

--- a/test/EventManagerPriorityTest.php
+++ b/test/EventManagerPriorityTest.php
@@ -16,7 +16,7 @@ use SplQueue;
 
 class EventManagerPriorityTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->identifiers  = [__CLASS__];
         $this->sharedEvents = new SharedEventManager();
@@ -49,7 +49,7 @@ class EventManagerPriorityTest extends TestCase
         $event = $this->createEvent();
         $this->events->triggerEvent($event);
         $values = iterator_to_array($event->getParam('accumulator'));
-        $this->assertEquals(
+        self::assertEquals(
             [4, 3, 2, 1, 0, -1],
             $values,
             sprintf("Did not receive values in priority order: %s\n", var_export($values, 1))
@@ -65,7 +65,7 @@ class EventManagerPriorityTest extends TestCase
         $event = $this->createEvent();
         $this->events->triggerEvent($event);
         $values = iterator_to_array($event->getParam('accumulator'));
-        $this->assertEquals(
+        self::assertEquals(
             [-1, 0, 1, 2, 3, 4],
             $values,
             sprintf("Did not receive values in attachment order: %s\n", var_export($values, 1))
@@ -81,7 +81,7 @@ class EventManagerPriorityTest extends TestCase
         $event = $this->createEvent();
         $this->events->triggerEvent($event);
         $values = iterator_to_array($event->getParam('accumulator'));
-        $this->assertEquals(
+        self::assertEquals(
             [1, 2, 3],
             $values,
             sprintf("Did not receive wildcard values after explicit listeners: %s\n", var_export($values, 1))
@@ -97,7 +97,7 @@ class EventManagerPriorityTest extends TestCase
         $event = $this->createEvent();
         $this->events->triggerEvent($event);
         $values = iterator_to_array($event->getParam('accumulator'));
-        $this->assertEquals(
+        self::assertEquals(
             [1, 2, 3],
             $values,
             sprintf("Did not receive shared listener values after wildcard listeners: %s\n", var_export($values, 1))
@@ -113,7 +113,7 @@ class EventManagerPriorityTest extends TestCase
         $event = $this->createEvent();
         $this->events->triggerEvent($event);
         $values = iterator_to_array($event->getParam('accumulator'));
-        $this->assertEquals(
+        self::assertEquals(
             [1, 2, 3],
             $values,
             sprintf(
@@ -132,7 +132,7 @@ class EventManagerPriorityTest extends TestCase
         $event = $this->createEvent();
         $this->events->triggerEvent($event);
         $values = iterator_to_array($event->getParam('accumulator'));
-        $this->assertEquals(
+        self::assertEquals(
             [1, 2, 3],
             $values,
             sprintf(
@@ -151,7 +151,7 @@ class EventManagerPriorityTest extends TestCase
         $event = $this->createEvent();
         $this->events->triggerEvent($event);
         $values = iterator_to_array($event->getParam('accumulator'));
-        $this->assertEquals(
+        self::assertEquals(
             [1, 2, 3],
             $values,
             sprintf(
@@ -200,11 +200,11 @@ class EventManagerPriorityTest extends TestCase
         $this->events->triggerEvent($event);
 
         $values = $report = iterator_to_array($event->getParam('accumulator'));
-        $this->assertCount(28, $values);
+        self::assertCount(28, $values);
         $original = array_shift($values);
         do {
             $compare = array_shift($values);
-            $this->assertLessThan(
+            self::assertLessThan(
                 $original,
                 $compare,
                 sprintf("Did not receive values in expected order: %s\n", var_export($report, 1))

--- a/test/EventManagerTest.php
+++ b/test/EventManagerTest.php
@@ -12,18 +12,16 @@ use Laminas\EventManager\Event;
 use Laminas\EventManager\EventInterface;
 use Laminas\EventManager\EventManager;
 use Laminas\EventManager\Exception;
-use Laminas\EventManager\ListenerAggregateInterface;
 use Laminas\EventManager\ResponseCollection;
 use Laminas\EventManager\SharedEventManager;
 use Laminas\EventManager\SharedEventManagerInterface;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 use ReflectionProperty;
 use stdClass;
 
 class EventManagerTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         if (isset($this->message)) {
             unset($this->message);
@@ -72,8 +70,8 @@ class EventManagerTest extends TestCase
         $listeners = $this->getListenersForEvent('test', $this->events);
         // Get first (and only) priority queue of listeners for event
         $listeners = array_shift($listeners);
-        $this->assertCount(1, $listeners);
-        $this->assertContains($listener, $listeners);
+        self::assertCount(1, $listeners);
+        self::assertContains($listener, $listeners);
         return [
             'event'    => 'test',
             'events'   => $this->events,
@@ -95,23 +93,23 @@ class EventManagerTest extends TestCase
     public function testAttachShouldAddReturnTheListener($event)
     {
         $listener  = [$this, __METHOD__];
-        $this->assertSame($listener, $this->events->attach($event, $listener));
+        self::assertSame($listener, $this->events->attach($event, $listener));
     }
 
     public function testAttachShouldAddEventIfItDoesNotExist()
     {
-        $this->assertAttributeEmpty('events', $this->events);
+        self::assertAttributeEmpty('events', $this->events);
         $listener = $this->events->attach('test', [$this, __METHOD__]);
         $events = $this->getEventListFromManager($this->events);
-        $this->assertNotEmpty($events);
-        $this->assertContains('test', $events);
+        self::assertNotEmpty($events);
+        self::assertContains('test', $events);
     }
 
     public function testTriggerShouldTriggerAttachedListeners()
     {
         $listener = $this->events->attach('test', [$this, 'handleTestEvent']);
         $this->events->trigger('test', $this, ['message' => 'test message']);
-        $this->assertEquals('test message', $this->message);
+        self::assertEquals('test message', $this->message);
     }
 
     public function testTriggerShouldReturnAllListenerReturnValues()
@@ -125,10 +123,10 @@ class EventManagerTest extends TestCase
             return str_rot13($string);
         });
         $responses = $this->events->trigger('string.transform', $this, ['string' => ' foo ']);
-        $this->assertInstanceOf(ResponseCollection::class, $responses);
-        $this->assertEquals(2, $responses->count());
-        $this->assertEquals('foo', $responses->first());
-        $this->assertEquals(\str_rot13(' foo '), $responses->last());
+        self::assertInstanceOf(ResponseCollection::class, $responses);
+        self::assertEquals(2, $responses->count());
+        self::assertEquals('foo', $responses->first());
+        self::assertEquals(\str_rot13(' foo '), $responses->last());
     }
 
     public function testTriggerUntilShouldReturnAsSoonAsCallbackReturnsTrue()
@@ -149,8 +147,8 @@ class EventManagerTest extends TestCase
             $this,
             ['string' => 'foo', 'search' => 'f']
         );
-        $this->assertInstanceOf(ResponseCollection::class, $responses);
-        $this->assertSame(0, $responses->last());
+        self::assertInstanceOf(ResponseCollection::class, $responses);
+        self::assertSame(0, $responses->last());
     }
 
     public function testTriggerResponseCollectionContains()
@@ -164,9 +162,9 @@ class EventManagerTest extends TestCase
             return str_rot13($string);
         });
         $responses = $this->events->trigger('string.transform', $this, ['string' => ' foo ']);
-        $this->assertTrue($responses->contains('foo'));
-        $this->assertTrue($responses->contains(\str_rot13(' foo ')));
-        $this->assertFalse($responses->contains(' foo '));
+        self::assertTrue($responses->contains('foo'));
+        self::assertTrue($responses->contains(\str_rot13(' foo ')));
+        self::assertFalse($responses->contains(' foo '));
     }
 
     public function handleTestEvent($e)
@@ -192,11 +190,11 @@ class EventManagerTest extends TestCase
         $responses = $this->events->triggerUntil(function ($result) {
             return ($result === 'found');
         }, 'foo.bar', $this);
-        $this->assertInstanceOf(ResponseCollection::class, $responses);
-        $this->assertTrue($responses->stopped());
+        self::assertInstanceOf(ResponseCollection::class, $responses);
+        self::assertTrue($responses->stopped());
         $result = $responses->last();
-        $this->assertEquals('found', $result);
-        $this->assertFalse($responses->contains('zero'));
+        self::assertEquals('found', $result);
+        self::assertFalse($responses->contains('zero'));
     }
 
     public function testTriggerUntilShouldMarkResponseCollectionStoppedWhenConditionMetByLastListener()
@@ -211,9 +209,9 @@ class EventManagerTest extends TestCase
         $responses = $this->events->triggerUntil(function ($result) {
             return ($result === 'found');
         }, 'foo.bar', $this);
-        $this->assertInstanceOf(ResponseCollection::class, $responses);
-        $this->assertTrue($responses->stopped());
-        $this->assertEquals('found', $responses->last());
+        self::assertInstanceOf(ResponseCollection::class, $responses);
+        self::assertTrue($responses->stopped());
+        self::assertEquals('found', $responses->last());
     }
 
     public function testResponseCollectionIsNotStoppedWhenNoCallbackMatchedByTriggerUntil()
@@ -228,9 +226,9 @@ class EventManagerTest extends TestCase
         $responses = $this->events->triggerUntil(function ($result) {
             return ($result === 'never found');
         }, 'foo.bar', $this);
-        $this->assertInstanceOf(ResponseCollection::class, $responses);
-        $this->assertFalse($responses->stopped());
-        $this->assertEquals('zero', $responses->last());
+        self::assertInstanceOf(ResponseCollection::class, $responses);
+        self::assertFalse($responses->stopped());
+        self::assertEquals('zero', $responses->last());
     }
 
     public function testCallingEventsStopPropagationMethodHaltsEventEmission()
@@ -243,12 +241,12 @@ class EventManagerTest extends TestCase
         // @codingStandardsIgnoreEnd
 
         $responses = $this->events->trigger('foo.bar');
-        $this->assertInstanceOf(ResponseCollection::class, $responses);
-        $this->assertTrue($responses->stopped());
-        $this->assertEquals('nada', $responses->last());
-        $this->assertTrue($responses->contains('bogus'));
-        $this->assertFalse($responses->contains('found'));
-        $this->assertFalse($responses->contains('zero'));
+        self::assertInstanceOf(ResponseCollection::class, $responses);
+        self::assertTrue($responses->stopped());
+        self::assertEquals('nada', $responses->last());
+        self::assertTrue($responses->contains('bogus'));
+        self::assertFalse($responses->contains('found'));
+        self::assertFalse($responses->contains('zero'));
     }
 
     public function testCanAlterParametersWithinAEvent()
@@ -264,7 +262,7 @@ class EventManagerTest extends TestCase
         });
 
         $responses = $this->events->trigger('foo.bar');
-        $this->assertEquals('bar:baz', $responses->last());
+        self::assertEquals('bar:baz', $responses->last());
     }
 
     public function testParametersArePassedToEventByReference()
@@ -278,8 +276,8 @@ class EventManagerTest extends TestCase
         // @codingStandardsIgnoreEnd
 
         $responses = $this->events->trigger('foo.bar', $this, $args);
-        $this->assertEquals('FOO', $args['foo']);
-        $this->assertEquals('BAR', $args['bar']);
+        self::assertEquals('FOO', $args['foo']);
+        self::assertEquals('BAR', $args['bar']);
     }
 
     public function testCanPassObjectForEventParameters()
@@ -291,8 +289,8 @@ class EventManagerTest extends TestCase
         // @codingStandardsIgnoreEnd
 
         $responses = $this->events->trigger('foo.bar', $this, $params);
-        $this->assertEquals('FOO', $params->foo);
-        $this->assertEquals('BAR', $params->bar);
+        self::assertEquals('FOO', $params->foo);
+        self::assertEquals('BAR', $params->bar);
     }
 
     public function testCanPassEventObjectAsSoleArgumentToTriggerEvent()
@@ -305,7 +303,7 @@ class EventManagerTest extends TestCase
             return $e;
         });
         $responses = $this->events->triggerEvent($event);
-        $this->assertSame($event, $responses->last());
+        self::assertSame($event, $responses->last());
     }
 
     public function testCanPassEventObjectAndCallbackToTriggerEventUntil()
@@ -320,16 +318,16 @@ class EventManagerTest extends TestCase
         $responses = $this->events->triggerEventUntil(function ($r) {
             return ($r instanceof EventInterface);
         }, $event);
-        $this->assertTrue($responses->stopped());
-        $this->assertSame($event, $responses->last());
+        self::assertTrue($responses->stopped());
+        self::assertSame($event, $responses->last());
     }
 
     public function testIdentifiersAreNotInjectedWhenNoSharedManagerProvided()
     {
         $events = new EventManager(null, [__CLASS__, get_class($this)]);
         $identifiers = $events->getIdentifiers();
-        $this->assertInternalType('array', $identifiers);
-        $this->assertEmpty($identifiers);
+        self::assertIsArray($identifiers);
+        self::assertEmpty($identifiers);
     }
 
     public function testDuplicateIdentifiersAreNotRegistered()
@@ -337,18 +335,18 @@ class EventManagerTest extends TestCase
         $sharedEvents = $this->prophesize(SharedEventManagerInterface::class)->reveal();
         $events = new EventManager($sharedEvents, [__CLASS__, get_class($this)]);
         $identifiers = $events->getIdentifiers();
-        $this->assertSame(count($identifiers), 1);
-        $this->assertSame($identifiers[0], __CLASS__);
+        self::assertSame(count($identifiers), 1);
+        self::assertSame($identifiers[0], __CLASS__);
         $events->addIdentifiers([__CLASS__]);
-        $this->assertSame(count($identifiers), 1);
-        $this->assertSame($identifiers[0], __CLASS__);
+        self::assertSame(count($identifiers), 1);
+        self::assertSame($identifiers[0], __CLASS__);
     }
 
     public function testIdentifierGetterSetters()
     {
         $identifiers = ['foo', 'bar'];
         $this->events->setIdentifiers($identifiers);
-        $this->assertSame($this->events->getIdentifiers(), $identifiers);
+        self::assertSame($this->events->getIdentifiers(), $identifiers);
         $identifiers[] = 'baz';
         $this->events->addIdentifiers($identifiers);
 
@@ -356,7 +354,7 @@ class EventManagerTest extends TestCase
         $expectedIdentifiers = $this->events->getIdentifiers();
         sort($expectedIdentifiers);
         sort($identifiers);
-        $this->assertSame($expectedIdentifiers, $identifiers);
+        self::assertSame($expectedIdentifiers, $identifiers);
     }
 
     public function testListenersAttachedWithWildcardAreTriggeredForAllEvents()
@@ -371,7 +369,7 @@ class EventManagerTest extends TestCase
 
         foreach (['foo', 'bar', 'baz'] as $event) {
             $this->events->trigger($event);
-            $this->assertContains($event, $test->events);
+            self::assertContains($event, $test->events);
         }
     }
 
@@ -387,8 +385,8 @@ class EventManagerTest extends TestCase
         $event->stopPropagation(true);
         $this->events->triggerEvent($event);
 
-        $this->assertFalse($marker->propagationIsStopped);
-        $this->assertFalse($event->propagationIsStopped());
+        self::assertFalse($marker->propagationIsStopped);
+        self::assertFalse($event->propagationIsStopped());
     }
 
     public function testTriggerEventUntilSetsStopPropagationFlagToFalse()
@@ -406,13 +404,13 @@ class EventManagerTest extends TestCase
         $event->stopPropagation(true);
         $this->events->triggerEventUntil($criteria, $event);
 
-        $this->assertFalse($marker->propagationIsStopped);
-        $this->assertFalse($event->propagationIsStopped());
+        self::assertFalse($marker->propagationIsStopped);
+        self::assertFalse($event->propagationIsStopped());
     }
 
     public function testCreatesAnEventPrototypeAtInstantiation()
     {
-        $this->assertAttributeInstanceOf(EventInterface::class, 'eventPrototype', $this->events);
+        self::assertAttributeInstanceOf(EventInterface::class, 'eventPrototype', $this->events);
     }
 
     public function testSetEventPrototype()
@@ -420,42 +418,42 @@ class EventManagerTest extends TestCase
         $event = $this->prophesize(EventInterface::class)->reveal();
         $this->events->setEventPrototype($event);
 
-        $this->assertAttributeSame($event, 'eventPrototype', $this->events);
+        self::assertAttributeSame($event, 'eventPrototype', $this->events);
     }
 
     public function testSharedManagerClearListenersReturnsFalse()
     {
         $shared = new SharedEventManager();
-        $this->assertFalse($shared->clearListeners('foo'));
+        self::assertFalse($shared->clearListeners('foo'));
     }
 
     public function testResponseCollectionLastReturnsNull()
     {
         $responses = $this->events->trigger('string.transform', $this, ['string' => ' foo ']);
-        $this->assertNull($responses->last());
+        self::assertNull($responses->last());
     }
 
     public function testCanAddWildcardListenersAfterFirstTrigger()
     {
         $this->events->attach('foo', function ($e) {
-            $this->assertEquals('foo', $e->getName());
+            self::assertEquals('foo', $e->getName());
         });
         $this->events->trigger('foo');
 
         $triggered = false;
         $this->events->attach('*', function ($e) use (&$triggered) {
-            $this->assertEquals('foo', $e->getName());
+            self::assertEquals('foo', $e->getName());
             $triggered = true;
         });
         $this->events->trigger('foo');
-        $this->assertTrue($triggered, 'Wildcard listener was not triggered');
+        self::assertTrue($triggered, 'Wildcard listener was not triggered');
     }
 
     public function testCanInjectSharedManagerDuringConstruction()
     {
         $shared = $this->prophesize(SharedEventManagerInterface::class)->reveal();
         $events = new EventManager($shared);
-        $this->assertSame($shared, $events->getSharedManager());
+        self::assertSame($shared, $events->getSharedManager());
     }
 
     public function invalidEventsForAttach()
@@ -494,16 +492,16 @@ class EventManagerTest extends TestCase
             $this->events->attach($event, $listener);
         }
 
-        $this->assertEquals($events, $this->getEventListFromManager($this->events));
+        self::assertEquals($events, $this->getEventListFromManager($this->events));
         $this->events->clearListeners('foo');
-        $this->assertCount(
+        self::assertCount(
             0,
             $this->getListenersForEvent('foo', $this->events),
             'Event foo listeners were not cleared'
         );
 
         foreach (['bar', 'baz'] as $event) {
-            $this->assertCount(
+            self::assertCount(
                 1,
                 $this->getListenersForEvent($event, $this->events),
                 sprintf(
@@ -521,14 +519,14 @@ class EventManagerTest extends TestCase
 
         $shared = new SharedEventManager();
         $shared->attach(__CLASS__, $name, function ($event) use ($name, &$triggered) {
-            $this->assertEquals($name, $event->getName());
+            self::assertEquals($name, $event->getName());
             $triggered = true;
         });
 
         $events = new EventManager($shared, [__CLASS__]);
 
         $events->trigger(__FUNCTION__);
-        $this->assertTrue($triggered, 'Shared listener was not triggered');
+        self::assertTrue($triggered, 'Shared listener was not triggered');
     }
 
     public function testWillTriggerSharedWildcardListeners()
@@ -538,14 +536,14 @@ class EventManagerTest extends TestCase
 
         $shared = new SharedEventManager();
         $shared->attach('*', $name, function ($event) use ($name, &$triggered) {
-            $this->assertEquals($name, $event->getName());
+            self::assertEquals($name, $event->getName());
             $triggered = true;
         });
 
         $events = new EventManager($shared, [__CLASS__]);
 
         $events->trigger(__FUNCTION__);
-        $this->assertTrue($triggered, 'Shared listener was not triggered');
+        self::assertTrue($triggered, 'Shared listener was not triggered');
     }
 
     /**
@@ -560,8 +558,8 @@ class EventManagerTest extends TestCase
         $events->detach($listener, $event);
 
         $listeners = $this->getListenersForEvent($event, $events);
-        $this->assertCount(0, $listeners);
-        $this->assertNotContains($listener, $listeners);
+        self::assertCount(0, $listeners);
+        self::assertNotContains($listener, $listeners);
     }
 
     public function testDetachDoesNothingIfEventIsNotPresentInManager()
@@ -573,7 +571,7 @@ class EventManagerTest extends TestCase
         $listeners = $this->getListenersForEvent('foo', $this->events);
         // get first (and only) priority queue from listeners
         $listeners = array_shift($listeners);
-        $this->assertContains($callback, $listeners);
+        self::assertContains($callback, $listeners);
     }
 
     /**
@@ -598,15 +596,15 @@ class EventManagerTest extends TestCase
 
         // First, check the wildcard event queue
         $listeners = $this->getListenersForEvent('*', $this->events);
-        $this->assertEmpty($listeners);
+        self::assertEmpty($listeners);
 
         // Next, verify it's not in any of the specific event queues
         foreach ($events as $event) {
             $listeners = $this->getListenersForEvent($event, $this->events);
             // Get listeners for first and only priority queue
             $listeners = array_shift($listeners);
-            $this->assertCount(1, $listeners);
-            $this->assertNotContains($wildcardListener, $listeners);
+            self::assertCount(1, $listeners);
+            self::assertNotContains($wildcardListener, $listeners);
         }
 
         return [
@@ -627,7 +625,7 @@ class EventManagerTest extends TestCase
 
         foreach ($eventNames as $event) {
             $results = $events->trigger($event);
-            $this->assertFalse($results->contains($notContains), 'Discovered unexpected wildcard value in results');
+            self::assertFalse($results->contains($notContains), 'Discovered unexpected wildcard value in results');
         }
     }
 
@@ -644,8 +642,8 @@ class EventManagerTest extends TestCase
 
         foreach ($eventNames as $event) {
             $listeners = $this->getListenersForEvent($event, $events);
-            $this->assertCount(0, $listeners);
-            $this->assertNotContains($listener, $listeners);
+            self::assertCount(0, $listeners);
+            self::assertNotContains($listener, $listeners);
         }
     }
 
@@ -661,7 +659,7 @@ class EventManagerTest extends TestCase
         $listeners = $this->getListenersForEvent('foo', $this->events);
         // Get the listeners for the first priority queue
         $listeners = array_shift($listeners);
-        $this->assertCount(
+        self::assertCount(
             2,
             $listeners,
             sprintf(
@@ -670,15 +668,15 @@ class EventManagerTest extends TestCase
                 var_export($listeners, 1)
             )
         );
-        $this->assertContains($listener, $listeners);
-        $this->assertContains($alternateListener, $listeners);
+        self::assertContains($listener, $listeners);
+        self::assertContains($alternateListener, $listeners);
 
         $this->events->detach($listener, 'foo');
 
         $listeners = $this->getListenersForEvent('foo', $this->events);
         // Get the listeners for the first priority queue
         $listeners = array_shift($listeners);
-        $this->assertCount(
+        self::assertCount(
             1,
             $listeners,
             sprintf(
@@ -687,8 +685,8 @@ class EventManagerTest extends TestCase
                 var_export($listeners, 1)
             )
         );
-        $this->assertNotContains($listener, $listeners);
-        $this->assertContains($alternateListener, $listeners);
+        self::assertNotContains($listener, $listeners);
+        self::assertContains($alternateListener, $listeners);
     }
 
     public function invalidEventsForDetach()
@@ -721,13 +719,13 @@ class EventManagerTest extends TestCase
         }
 
         $listeners = $this->getListenersForEvent('foo', $this->events);
-        $this->assertCount(5, $listeners);
+        self::assertCount(5, $listeners);
 
         $this->events->detach($listener, 'foo');
 
         $listeners = $this->getListenersForEvent('foo', $this->events);
-        $this->assertCount(0, $listeners);
-        $this->assertNotContains($listener, $listeners);
+        self::assertCount(0, $listeners);
+        self::assertNotContains($listener, $listeners);
     }
 
     public function eventsMissingNames()
@@ -771,12 +769,12 @@ class EventManagerTest extends TestCase
 
         $triggered = false;
         $this->events->attach('test', function ($e) use ($event, &$triggered) {
-            $this->assertSame($event->reveal(), $e);
+            self::assertSame($event->reveal(), $e);
             $triggered = true;
         });
 
         $this->events->triggerEvent($event->reveal());
-        $this->assertTrue($triggered, 'Listener for event was not triggered');
+        self::assertTrue($triggered, 'Listener for event was not triggered');
     }
 
     public function testTriggerEventUntilAcceptsEventInstanceAndTriggersListenersUntilCallbackEvaluatesTrue()
@@ -792,13 +790,13 @@ class EventManagerTest extends TestCase
 
         $triggeredOne = false;
         $this->events->attach('test', function ($e) use ($event, &$triggeredOne) {
-            $this->assertSame($event->reveal(), $e);
+            self::assertSame($event->reveal(), $e);
             $triggeredOne = true;
         });
 
         $triggeredTwo = false;
         $this->events->attach('test', function ($e) use ($event, &$triggeredTwo) {
-            $this->assertSame($event->reveal(), $e);
+            self::assertSame($event->reveal(), $e);
             $triggeredTwo = true;
             return true;
         });
@@ -808,7 +806,7 @@ class EventManagerTest extends TestCase
         });
 
         $this->events->triggerEventUntil($callback, $event->reveal());
-        $this->assertTrue($triggeredOne, 'First Listener for event was not triggered');
-        $this->assertTrue($triggeredTwo, 'First Listener for event was not triggered');
+        self::assertTrue($triggeredOne, 'First Listener for event was not triggered');
+        self::assertTrue($triggeredTwo, 'First Listener for event was not triggered');
     }
 }

--- a/test/EventTest.php
+++ b/test/EventTest.php
@@ -26,9 +26,9 @@ class EventTest extends TestCase
 
         $event = new Event($name, $target, $params);
 
-        $this->assertEquals($name, $event->getName());
-        $this->assertEquals($target, $event->getTarget());
-        $this->assertEquals($params, $event->getParams());
+        self::assertEquals($name, $event->getName());
+        self::assertEquals($target, $event->getTarget());
+        self::assertEquals($params, $event->getParams());
     }
 
     public function testSetParamsWithInvalidParameter()
@@ -43,7 +43,7 @@ class EventTest extends TestCase
         $event = new Event('foo', 'bar', []);
         $default = 1;
 
-        $this->assertEquals($default, $event->getParam('foo', $default));
+        self::assertEquals($default, $event->getParam('foo', $default));
     }
 
     public function testGetParamReturnsDefaultForObject()
@@ -52,7 +52,7 @@ class EventTest extends TestCase
         $event = new Event('foo', 'bar', $params);
         $default = 1;
 
-        $this->assertEquals($default, $event->getParam('foo', $default));
+        self::assertEquals($default, $event->getParam('foo', $default));
     }
 
     public function testGetParamReturnsForObject()
@@ -65,6 +65,6 @@ class EventTest extends TestCase
         $event = new Event('foo', 'bar', $params);
         $default = 1;
 
-        $this->assertEquals($value, $event->getParam($key));
+        self::assertEquals($value, $event->getParam($key));
     }
 }

--- a/test/FilterChainTest.php
+++ b/test/FilterChainTest.php
@@ -22,7 +22,7 @@ class FilterChainTest extends TestCase
      */
     protected $filterchain;
 
-    public function setUp()
+    protected function setUp() : void
     {
         if (isset($this->message)) {
             unset($this->message);
@@ -33,25 +33,25 @@ class FilterChainTest extends TestCase
     public function testSubscribeShouldReturnCallbackHandler()
     {
         $handle = $this->filterchain->attach([ $this, __METHOD__ ]);
-        $this->assertSame([ $this, __METHOD__ ], $handle);
+        self::assertSame([ $this, __METHOD__ ], $handle);
     }
 
     public function testSubscribeShouldAddCallbackHandlerToFilters()
     {
         $handler  = $this->filterchain->attach([$this, __METHOD__]);
         $handlers = $this->filterchain->getFilters();
-        $this->assertEquals(1, count($handlers));
-        $this->assertTrue($handlers->contains($handler));
+        self::assertEquals(1, count($handlers));
+        self::assertTrue($handlers->contains($handler));
     }
 
     public function testDetachShouldRemoveCallbackHandlerFromFilters()
     {
         $handle = $this->filterchain->attach([ $this, __METHOD__ ]);
         $handles = $this->filterchain->getFilters();
-        $this->assertTrue($handles->contains($handle));
+        self::assertTrue($handles->contains($handle));
         $this->filterchain->detach($handle);
         $handles = $this->filterchain->getFilters();
-        $this->assertFalse($handles->contains($handle));
+        self::assertFalse($handles->contains($handle));
     }
 
     public function testDetachShouldReturnFalseIfCallbackHandlerDoesNotExist()
@@ -59,13 +59,13 @@ class FilterChainTest extends TestCase
         $handle1 = $this->filterchain->attach([ $this, __METHOD__ ]);
         $this->filterchain->clearFilters();
         $handle2 = $this->filterchain->attach([ $this, 'handleTestTopic' ]);
-        $this->assertFalse($this->filterchain->detach($handle1));
+        self::assertFalse($this->filterchain->detach($handle1));
     }
 
     public function testRetrievingAttachedFiltersShouldReturnEmptyArrayWhenNoFiltersExist()
     {
         $handles = $this->filterchain->getFilters();
-        $this->assertEquals(0, count($handles));
+        self::assertEquals(0, count($handles));
     }
 
     public function testFilterChainShouldReturnLastResponse()
@@ -82,7 +82,7 @@ class FilterChainTest extends TestCase
             return str_rot13($string);
         });
         $value = $this->filterchain->run($this, ['string' => ' foo ']);
-        $this->assertEquals(str_rot13(trim(' foo ')), $value);
+        self::assertEquals(str_rot13(trim(' foo ')), $value);
     }
 
     public function testFilterIsPassedContextAndArguments()
@@ -90,9 +90,9 @@ class FilterChainTest extends TestCase
         $this->filterchain->attach([ $this, 'filterTestCallback1' ]);
         $obj = (object) ['foo' => 'bar', 'bar' => 'baz'];
         $value = $this->filterchain->run($this, ['object' => $obj]);
-        $this->assertEquals('filtered', $value);
-        $this->assertEquals('filterTestCallback1', $this->message);
-        $this->assertEquals('foobarbaz', $obj->foo);
+        self::assertEquals('filtered', $value);
+        self::assertEquals('filterTestCallback1', $this->message);
+        self::assertEquals('foobarbaz', $obj->foo);
     }
 
     public function testInterceptingFilterShouldReceiveChain()
@@ -118,7 +118,7 @@ class FilterChainTest extends TestCase
             return hash('md5', $string);
         }, 100);
         $value = $this->filterchain->run($this, ['string' => ' foo ']);
-        $this->assertEquals(str_rot13(trim(' foo ')), $value);
+        self::assertEquals(str_rot13(trim(' foo ')), $value);
     }
 
     public function handleTestTopic($message)
@@ -137,18 +137,18 @@ class FilterChainTest extends TestCase
 
     public function filterReceivalCallback($context, array $params, $chain)
     {
-        $this->assertInstanceOf(FilterIterator::class, $chain);
+        self::assertInstanceOf(FilterIterator::class, $chain);
     }
 
     public function testRunReturnsNullWhenChainIsEmpty()
     {
         $filterChain = new FilterChain();
-        $this->assertNull($filterChain->run(null));
+        self::assertNull($filterChain->run(null));
     }
 
     public function testGetResponses()
     {
         $filterChain = new FilterChain();
-        $this->assertNull($filterChain->getResponses());
+        self::assertNull($filterChain->getResponses());
     }
 }

--- a/test/FilterIteratorTest.php
+++ b/test/FilterIteratorTest.php
@@ -21,19 +21,19 @@ class FilterIteratorTest extends TestCase
     public function testNextReturnsNullOnEmptyChain()
     {
         $filterIterator = new FilterIterator();
-        $this->assertNull($filterIterator->next([]));
+        self::assertNull($filterIterator->next([]));
     }
 
     public function testNextReturnsNullWithEmptyHeap()
     {
         $filterIterator = new FilterIterator();
-        $this->assertNull($filterIterator->next([0, 1, 2]));
+        self::assertNull($filterIterator->next([0, 1, 2]));
     }
 
     public function testContainsReturnsFalseForInvalidElement()
     {
         $filterIterator = new FilterIterator();
-        $this->assertFalse($filterIterator->contains('foo'));
+        self::assertFalse($filterIterator->contains('foo'));
     }
 
     public function testContainsReturnsTrueForValidElement()
@@ -42,14 +42,14 @@ class FilterIteratorTest extends TestCase
         };
         $filterIterator = new FilterIterator();
         $filterIterator->insert($callback, 1);
-        $this->assertTrue($filterIterator->contains($callback));
+        self::assertTrue($filterIterator->contains($callback));
     }
 
     public function testRemoveFromEmptyQueueReturnsFalse()
     {
         $filterIterator = new FilterIterator();
 
-        $this->assertFalse($filterIterator->remove('foo'));
+        self::assertFalse($filterIterator->remove('foo'));
     }
 
     public function testRemoveUnrecognizedItemFromQueueReturnsFalse()
@@ -59,7 +59,7 @@ class FilterIteratorTest extends TestCase
         $filterIterator = new FilterIterator();
         $filterIterator->insert($callback, 1);
 
-        $this->assertFalse($filterIterator->remove(clone $callback));
+        self::assertFalse($filterIterator->remove(clone $callback));
     }
 
     public function testRemoveValidItemFromQueueReturnsTrue()
@@ -69,7 +69,7 @@ class FilterIteratorTest extends TestCase
         $filterIterator = new FilterIterator();
         $filterIterator->insert($callback, 1);
 
-        $this->assertTrue($filterIterator->remove($callback));
+        self::assertTrue($filterIterator->remove($callback));
     }
 
     public function testNextReturnsNullWhenFilterChainIsEmpty()
@@ -78,7 +78,7 @@ class FilterIteratorTest extends TestCase
 
         $chain = new FilterIterator();
 
-        $this->assertNull($filterIterator->next([0, 1, 2], ['foo', 'bar'], $chain));
+        self::assertNull($filterIterator->next([0, 1, 2], ['foo', 'bar'], $chain));
     }
 
     public function invalidFilters()

--- a/test/LazyEventListenerTest.php
+++ b/test/LazyEventListenerTest.php
@@ -15,7 +15,7 @@ use Laminas\EventManager\LazyEventListener;
 
 class LazyEventListenerTest extends LazyListenerTest
 {
-    public function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         $this->listenerClass = LazyEventListener::class;
@@ -60,7 +60,7 @@ class LazyEventListenerTest extends LazyListenerTest
         ];
 
         $listener = new $class($struct, $this->container->reveal());
-        $this->assertInstanceOf($class, $listener);
+        self::assertInstanceOf($class, $listener);
         return $listener;
     }
 
@@ -69,7 +69,7 @@ class LazyEventListenerTest extends LazyListenerTest
      */
     public function testCanRetrieveEventFromListener($listener)
     {
-        $this->assertEquals('event', $listener->getEvent());
+        self::assertEquals('event', $listener->getEvent());
     }
 
     /**
@@ -77,7 +77,7 @@ class LazyEventListenerTest extends LazyListenerTest
      */
     public function testCanRetrievePriorityFromListener($listener)
     {
-        $this->assertEquals(5, $listener->getPriority());
+        self::assertEquals(5, $listener->getPriority());
     }
 
     public function testGetPriorityWillReturnProvidedPriorityIfNoneGivenAtInstantiation()
@@ -90,7 +90,7 @@ class LazyEventListenerTest extends LazyListenerTest
         ];
 
         $listener = new $class($struct, $this->container->reveal());
-        $this->assertInstanceOf($class, $listener);
-        $this->assertEquals(5, $listener->getPriority(5));
+        self::assertInstanceOf($class, $listener);
+        self::assertEquals(5, $listener->getPriority(5));
     }
 }

--- a/test/LazyListenerAggregateTest.php
+++ b/test/LazyListenerAggregateTest.php
@@ -20,7 +20,7 @@ use ReflectionProperty;
 
 class LazyListenerAggregateTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->container = $this->prophesize(ContainerInterface::class);
     }
@@ -106,9 +106,9 @@ class LazyListenerAggregateTest extends TestCase
         $r->setAccessible(true);
         $test = $r->getValue($aggregate);
 
-        $this->assertInstanceOf(LazyEventListener::class, $test[0]);
-        $this->assertEquals('event', $test[0]->getEvent());
-        $this->assertSame($listeners[1], $test[1], 'LazyEventListener instance changed during instantiation');
+        self::assertInstanceOf(LazyEventListener::class, $test[0]);
+        self::assertEquals('event', $test[0]->getEvent());
+        self::assertSame($listeners[1], $test[1], 'LazyEventListener instance changed during instantiation');
         return $listeners;
     }
 
@@ -156,10 +156,10 @@ class LazyListenerAggregateTest extends TestCase
         $r->setAccessible(true);
         $listeners = $r->getValue($aggregate);
 
-        $this->assertInternalType('array', $listeners);
-        $this->assertCount(1, $listeners);
+        self::assertIsArray($listeners);
+        self::assertCount(1, $listeners);
         $listener = array_shift($listeners);
-        $this->assertInstanceOf(LazyEventListener::class, $listener);
+        self::assertInstanceOf(LazyEventListener::class, $listener);
         $listener($event->reveal());
     }
 }

--- a/test/LazyListenerTest.php
+++ b/test/LazyListenerTest.php
@@ -18,7 +18,7 @@ use stdClass;
 
 class LazyListenerTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->listenerClass = LazyListener::class;
         $this->container = $this->prophesize(ContainerInterface::class);
@@ -105,7 +105,7 @@ class LazyListenerTest extends TestCase
         ];
 
         $listener = new $class($struct, $this->container->reveal());
-        $this->assertInstanceOf($class, $listener);
+        self::assertInstanceOf($class, $listener);
         return $listener;
     }
 
@@ -114,7 +114,7 @@ class LazyListenerTest extends TestCase
      */
     public function testInstatiationSetsListenerMethod($listener)
     {
-        $this->assertAttributeEquals('method', 'method', $listener);
+        self::assertAttributeEquals('method', 'method', $listener);
     }
 
     public function testLazyListenerActsAsInvokableAroundListenerCreation()
@@ -137,9 +137,9 @@ class LazyListenerTest extends TestCase
         ];
 
         $lazyListener = new $class($struct, $this->container->reveal());
-        $this->assertInstanceOf($class, $lazyListener);
+        self::assertInstanceOf($class, $lazyListener);
 
-        $this->assertEquals('RECEIVED', $lazyListener($event->reveal()));
+        self::assertEquals('RECEIVED', $lazyListener($event->reveal()));
     }
 
     public function testInvocationWillDelegateToContainerBuildMethodWhenPresentAndEnvIsNonEmpty()
@@ -168,8 +168,8 @@ class LazyListenerTest extends TestCase
         ];
 
         $lazyListener = new $class($struct, $container->reveal(), $env);
-        $this->assertInstanceOf($class, $lazyListener);
+        self::assertInstanceOf($class, $lazyListener);
 
-        $this->assertEquals('RECEIVED', $lazyListener($event->reveal()));
+        self::assertEquals('RECEIVED', $lazyListener($event->reveal()));
     }
 }

--- a/test/ListenerAggregateTraitTest.php
+++ b/test/ListenerAggregateTraitTest.php
@@ -10,7 +10,6 @@ namespace LaminasTest\EventManager;
 
 use Laminas\EventManager\EventManagerInterface;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 
 class ListenerAggregateTraitTest extends TestCase
 {
@@ -34,15 +33,15 @@ class ListenerAggregateTraitTest extends TestCase
         $aggregate->attach($events);
 
         $listeners = $aggregate->getCallbacks();
-        $this->assertInternalType('array', $listeners);
-        $this->assertCount(2, $listeners);
+        self::assertIsArray($listeners);
+        self::assertCount(2, $listeners);
 
         foreach ($listeners as $listener) {
-            $this->assertSame([$aggregate, 'doFoo'], $listener);
+            self::assertSame([$aggregate, 'doFoo'], $listener);
         }
 
         $aggregate->detach($events);
 
-        $this->assertAttributeSame([], 'listeners', $aggregate);
+        self::assertSame([], $aggregate->getCallbacks());
     }
 }

--- a/test/SharedEventManagerTest.php
+++ b/test/SharedEventManagerTest.php
@@ -17,7 +17,7 @@ use Prophecy\Argument;
 
 class SharedEventManagerTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->callback = function ($e) {
         };
@@ -91,7 +91,7 @@ class SharedEventManagerTest extends TestCase
         $this->manager->attach('IDENTIFIER', 'EVENT', $this->callback);
 
         $listeners = $this->getListeners($this->manager, ['IDENTIFIER'], 'EVENT');
-        $this->assertSame([$this->callback], $listeners);
+        self::assertSame([$this->callback], $listeners);
     }
 
     public function detachIdentifierAndEvent()
@@ -112,7 +112,7 @@ class SharedEventManagerTest extends TestCase
         $this->manager->attach('IDENTIFIER', 'EVENT', $this->callback);
         $this->manager->detach($this->callback, $identifier, $event);
         $listeners = $this->getListeners($this->manager, ['IDENTIFIER'], 'EVENT');
-        $this->assertSame([], $listeners);
+        self::assertSame([], $listeners);
     }
 
     public function testDetachDoesNothingIfIdentifierNotInManager()
@@ -121,7 +121,7 @@ class SharedEventManagerTest extends TestCase
         $this->manager->detach($this->callback, 'DIFFERENT-IDENTIFIER');
 
         $listeners = $this->getListeners($this->manager, ['IDENTIFIER'], 'EVENT');
-        $this->assertSame([$this->callback], $listeners);
+        self::assertSame([$this->callback], $listeners);
     }
 
     public function testDetachDoesNothingIfIdentifierDoesNotContainEvent()
@@ -129,14 +129,14 @@ class SharedEventManagerTest extends TestCase
         $this->manager->attach('IDENTIFIER', 'EVENT', $this->callback);
         $this->manager->detach($this->callback, 'IDENTIFIER', 'DIFFERENT-EVENT');
         $listeners = $this->getListeners($this->manager, ['IDENTIFIER'], 'EVENT');
-        $this->assertSame([$this->callback], $listeners);
+        self::assertSame([$this->callback], $listeners);
     }
 
     public function testWhenEventIsProvidedAndNoListenersFoundForIdentiferGetListenersWillReturnEmptyList()
     {
         $test = $this->manager->getListeners([ 'IDENTIFIER' ], 'EVENT');
-        $this->assertInternalType('array', $test);
-        $this->assertCount(0, $test);
+        self::assertIsArray($test);
+        self::assertCount(0, $test);
     }
 
     public function testWhenEventIsProvidedGetListenersReturnsAllListenersIncludingWildcardListeners()
@@ -152,7 +152,7 @@ class SharedEventManagerTest extends TestCase
         $this->manager->attach('IDENTIFIER', 'EVENT', $callback4);
 
         $test = $this->getListeners($this->manager, [ 'IDENTIFIER' ], 'EVENT');
-        $this->assertEquals([
+        self::assertEquals([
             $callback1,
             $callback4,
             $callback2,
@@ -171,7 +171,7 @@ class SharedEventManagerTest extends TestCase
         $this->manager->clearListeners('IDENTIFIER');
 
         $listeners = $this->getListeners($this->manager, [ 'IDENTIFIER' ], 'EVENT');
-        $this->assertSame(
+        self::assertSame(
             [$wildcardIdentifier],
             $listeners,
             sprintf(
@@ -193,23 +193,22 @@ class SharedEventManagerTest extends TestCase
         $this->manager->clearListeners('IDENTIFIER', 'EVENT');
 
         $listeners = $this->getListeners($this->manager, ['IDENTIFIER'], 'EVENT');
-        $this->assertInternalType('array', $listeners, 'Unexpected return value from getListeners() for event EVENT');
-        $this->assertCount(1, $listeners);
+        self::assertIsArray($listeners, 'Unexpected return value from getListeners() for event EVENT');
+        self::assertCount(1, $listeners);
         $listener = array_shift($listeners);
-        $this->assertSame($wildcard, $listener, sprintf(
+        self::assertSame($wildcard, $listener, sprintf(
             'Expected only wildcard listener on event EVENT after clearListener operation; received: %s',
             var_export($listener, 1)
         ));
 
         $listeners = $this->getListeners($this->manager, ['IDENTIFIER'], 'ALTERNATE');
-        $this->assertInternalType(
-            'array',
+        self::assertIsArray(
             $listeners,
             'Unexpected return value from getListeners() for event ALTERNATE'
         );
-        $this->assertCount(1, $listeners);
+        self::assertCount(1, $listeners);
         $listener = array_shift($listeners);
-        $this->assertSame($alternate, $listener, 'Unexpected listener list for event ALTERNATE');
+        self::assertSame($alternate, $listener, 'Unexpected listener list for event ALTERNATE');
     }
 
     public function testClearListenersDoesNotRemoveWildcardListenersWhenEventIsProvided()
@@ -224,17 +223,17 @@ class SharedEventManagerTest extends TestCase
         $this->manager->clearListeners('IDENTIFIER', 'EVENT');
 
         $listeners = $this->getListeners($this->manager, ['IDENTIFIER'], 'EVENT');
-        $this->assertContains(
+        self::assertContains(
             $wildcardEventListener,
             $listeners,
             'Event listener list after clear operation does not include wildcard event listener'
         );
-        $this->assertContains(
+        self::assertContains(
             $wildcardIdentifierListener,
             $listeners,
             'Event listener list after clear operation does not include wildcard identifier listener'
         );
-        $this->assertNotContains(
+        self::assertNotContains(
             $this->callback,
             $listeners,
             'Event listener list after clear operation includes explicitly attached listener and should not'
@@ -250,7 +249,7 @@ class SharedEventManagerTest extends TestCase
         $this->manager->clearListeners('IDENTIFIER', 'EVENT');
 
         // getListeners() always pulls in wildcard listeners
-        $this->assertEquals([1 => [
+        self::assertEquals([1 => [
             $this->callback,
         ]], $this->manager->getListeners([ 'IDENTIFIER' ], 'EVENT'));
     }

--- a/test/SharedListenerIntegrationTest.php
+++ b/test/SharedListenerIntegrationTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 class SharedListenerIntegrationTest extends TestCase
 {
-    public function setUp()
+    protected function setUp() : void
     {
         $this->identifiers = ['Foo', 'Bar', 'Baz'];
         $this->sharedEvents = new SharedEventManager();
@@ -31,7 +31,7 @@ class SharedListenerIntegrationTest extends TestCase
         for ($i = 0; $i < $iterations; $i += 1) {
             $this->events->trigger('foo');
         }
-        $this->assertSame($iterations, $listener->count);
+        self::assertSame($iterations, $listener->count);
     }
 
     public function testTriggeringSameEventMultipleTimesTriggersNewSharedListeners()
@@ -47,7 +47,7 @@ class SharedListenerIntegrationTest extends TestCase
         for ($i = 0; $i < 5; $i += 1) {
             $expected = 5 - $i;
             $listener = $listeners[$i];
-            $this->assertSame(
+            self::assertSame(
                 $expected,
                 $listener->count,
                 sprintf('Listener %s was not triggered expected %d times; instead %d', $i, $expected, $listener->count)
@@ -75,7 +75,7 @@ class SharedListenerIntegrationTest extends TestCase
 
         for ($i = 0; $i < 5; $i += 1) {
             $listener = $listeners[$i];
-            $this->assertEquals($i, $listener->count);
+            self::assertEquals($i, $listener->count);
         }
     }
 }

--- a/test/Test/EventListenerIntrospectionTraitTest.php
+++ b/test/Test/EventListenerIntrospectionTraitTest.php
@@ -18,7 +18,7 @@ class EventListenerIntrospectionTraitTest extends TestCase
 {
     use EventListenerIntrospectionTrait;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->events = new EventManager();
     }
@@ -31,7 +31,7 @@ class EventListenerIntrospectionTraitTest extends TestCase
         $this->events->attach('baz', function ($e) {});
         // @codingStandardsIgnoreEnd
 
-        $this->assertEquals(['foo', 'bar', 'baz'], $this->getEventsFromEventManager($this->events));
+        self::assertEquals(['foo', 'bar', 'baz'], $this->getEventsFromEventManager($this->events));
     }
 
     public function testGetListenersForEventReturnsIteratorOfListenersForEventInPriorityOrder()
@@ -51,10 +51,10 @@ class EventListenerIntrospectionTraitTest extends TestCase
         $this->events->attach('foo', $callback2, 5);
 
         $listeners = $this->getListenersForEvent('foo', $this->events);
-        $this->assertInstanceOf(Traversable::class, $listeners);
+        self::assertInstanceOf(Traversable::class, $listeners);
         $listeners = iterator_to_array($listeners);
 
-        $this->assertEquals([
+        self::assertEquals([
             $callback5,
             $callback1,
             $callback4,
@@ -80,10 +80,10 @@ class EventListenerIntrospectionTraitTest extends TestCase
         $this->events->attach('foo', $callback2);
 
         $listeners = $this->getListenersForEvent('foo', $this->events);
-        $this->assertInstanceOf(Traversable::class, $listeners);
+        self::assertInstanceOf(Traversable::class, $listeners);
         $listeners = iterator_to_array($listeners);
 
-        $this->assertEquals([
+        self::assertEquals([
             $callback5,
             $callback1,
             $callback4,
@@ -109,10 +109,10 @@ class EventListenerIntrospectionTraitTest extends TestCase
         $this->events->attach('foo', $callback2, 5);
 
         $listeners = $this->getListenersForEvent('foo', $this->events, true);
-        $this->assertInstanceOf(Traversable::class, $listeners);
+        self::assertInstanceOf(Traversable::class, $listeners);
         $listeners = iterator_to_array($listeners);
 
-        $this->assertEquals([
+        self::assertEquals([
             1 => $callback5,
             2 => $callback1,
             3 => $callback4,
@@ -138,9 +138,9 @@ class EventListenerIntrospectionTraitTest extends TestCase
         $this->events->attach('foo', $callback2, 2);
 
         $listeners = $this->getArrayOfListenersForEvent('foo', $this->events);
-        $this->assertInternalType('array', $listeners);
+        self::assertIsArray($listeners);
 
-        $this->assertEquals([
+        self::assertEquals([
             $callback5,
             $callback1,
             $callback3,
@@ -157,7 +157,7 @@ class EventListenerIntrospectionTraitTest extends TestCase
 
         $this->events->attach('foo', $callback, 7);
 
-        $this->assertListenerAtPriority($callback, 7, 'foo', $this->events);
+        self::assertListenerAtPriority($callback, 7, 'foo', $this->events);
     }
 
     public function testAssertListenerAtPriorityFailsWhenListenerIsNotFound()
@@ -179,7 +179,7 @@ class EventListenerIntrospectionTraitTest extends TestCase
 
         foreach ($permutations as $case => $arguments) {
             try {
-                $this->assertListenerAtPriority(
+                self::assertListenerAtPriority(
                     $arguments['listener'],
                     $arguments['priority'],
                     $arguments['event'],
@@ -187,7 +187,7 @@ class EventListenerIntrospectionTraitTest extends TestCase
                 );
                 $this->fail('assertListenerAtPriority assertion had a false positive for case ' . $case);
             } catch (ExpectationFailedException $e) {
-                $this->assertContains(sprintf(
+                self::assertContains(sprintf(
                     'Listener not found for event "%s" and priority %d',
                     $arguments['event'],
                     $arguments['priority']


### PR DESCRIPTION


|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | yes

### Description

Updates PHPUnit to version 8, as with version 9 there are too many issues
like prophecy, removed assertAttribute* assertions etc.

Update Travis CI matrix and composer php requirements + dependencies.

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
